### PR TITLE
Update build script for ntupliser

### DIFF
--- a/L1Trigger/TrackFindingTMTT/README.md
+++ b/L1Trigger/TrackFindingTMTT/README.md
@@ -8,9 +8,9 @@ cd CMSSW_9_3_8/src
 cmsenv
 
 git cms-init
-git remote add -t TMTT_938 TMTT https://github.com/CMS-TMTT/cmssw.git
-git fetch TMTT TMTT_938
-git cms-checkout-topic CMS-TMTT:TMTT_938
+git remote add -t tmtt_938_ntuple++ thesps https://github.com/thesps/cmssw.git
+git fetch thesps tmtt_938_ntuple++
+git cms-checkout-topic thesps:tmtt_938_ntuple++
 
 scramv1 b -j 8
 

--- a/L1Trigger/TrackFindingTMTT/test/BuildFile.xml
+++ b/L1Trigger/TrackFindingTMTT/test/BuildFile.xml
@@ -1,6 +1,50 @@
-<library   file="*.cc" name="L1trackLouiseCode">
-  <flags   EDM_PLUGIN="1"/>
-  <use name="TMTrackTrigger/TMTrackFinder"/>
-  <!-- # Add no-misleading-indentation option to avoid warnings about bug in Boost library. -->
-  <flags CXXFLAGS="-g -Wno-unused-variable -Wno-misleading-indentation"/>
-</library>
+<environment>
+  <library   file="*.cc" name="TrackFindingTrackletTests">
+    <flags   EDM_PLUGIN="1"/>
+    <use   name="FWCore/Framework"/>
+    <use   name="FWCore/PluginManager"/>
+    <use   name="FWCore/ParameterSet"/>
+    <use   name="Geometry/Records"/>
+    <use   name="Geometry/TrackerGeometryBuilder"/>
+    <use   name="Geometry/TrackerNumberingBuilder"/>
+    <use   name="Geometry/CommonDetUnit"/>
+    <use   name="CondFormats/Alignment"/>
+    <use   name="DataFormats/CaloTowers"/>    
+    <use   name="Geometry/CaloTopology"/>    
+    <use   name="Geometry/CaloGeometry"/>
+    <use   name="DataFormats/L1TrackTrigger"/>
+    <use   name="root"/>
+    <use   name="FastSimulation/Particle"/>
+    <use   name="FastSimulation/BaseParticlePropagator"/>
+    <use   name="heppdt"/>
+    <use   name="SimTracker/TrackerHitAssociation"/>
+    <use   name="SimTracker/TrackTriggerAssociation"/>
+    <use   name="DataFormats/Common"/>
+    <use   name="DataFormats/TrackerRecHit2D"/>
+    <use   name="SimDataFormats/Vertex"/>
+    <use   name="SimDataFormats/TrackingHit"/>
+    <use   name="SimDataFormats/CrossingFrame"/>
+    <use   name="SimDataFormats/TrackingAnalysis"/>
+    <use   name="RecoLocalTracker/SiPixelRecHits"/>
+    <use   name="PhysicsTools/UtilAlgos"/>
+    <use   name="FWCore/ServiceRegistry"/>
+    <use   name="clhep"/>
+    <use   name="DataFormats/EcalDigi"/>
+    <use   name="DataFormats/EcalDetId"/>
+    <use   name="DataFormats/HcalDigi"/>
+    <use   name="DataFormats/HcalDetId"/>
+    <use   name="TrackingTools/TrackAssociator"/>
+    <use   name="TrackingTools/TrajectoryState"/>
+    <use   name="PhysicsTools/CandUtils"/>
+    <use   name="FWCore/MessageLogger"/>
+    <use   name="DataFormats/L1Trigger"/>
+    <use   name="DataFormats/HepMCCandidate"/>
+    <use   name="CondFormats/L1TObjects"/>
+    <use   name="CondFormats/DataRecord"/>
+    <use   name="RecoTauTag/TauTagTools"/>
+    <use   name="RecoTracker/TkSeedGenerator"/>
+  <use   name="CommonTools/UtilAlgos"/>
+    <use   name="DataFormats/Phase2TrackerDigi"/>
+    <flags   CXXFLAGS="-g -O0"/>
+  </library>
+</environment>


### PR DESCRIPTION
This adds an extended build xml config for the ntupliser script that was borrowed from L Skinnari. The xml likely contains a lot more than the bare minimum but at least allows to run the ntupliser out of the box. 

I also updated the readme.md file to reflect the correct repository and branch if one is to setup an area of the ntupliser from scratch.